### PR TITLE
feat!: add method for getting full screen permission state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.5.3
+
+- added the `canUseFullScreenIntent()` method to determine whether the device can show full screen notifications in the locked state (Android only). You can use this value to determine whether to show dialog and subsequently call `requestFullIntentPermission()` to open the settings activity.
+- renamed the `requestFullIntentPermission()` to `openFullScreenNotificationsSettings()` to better reflect what it does and changed its return type to `Future<void>` from `Future<dynamic>`.
+
 ## 2.5.2
 * Add notification calling for Android `callingNotification`, thank @ebsangam https://github.com/hiennguyen92/flutter_callkit_incoming/pull/662
 * Add `logoUrl` properties (inside android prop) 

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
@@ -524,9 +524,14 @@ class CallkitNotificationManager(private val context: Context) {
         }
     }
 
-    fun requestFullIntentPermission(activity: Activity?) {
-        val canUseFullScreenIntent = getNotificationManager().canUseFullScreenIntent();
-        if (!canUseFullScreenIntent && Build.VERSION.SDK_INT > 33) {
+    fun canUseFullScreenIntent(): Boolean {
+        return getNotificationManager().canUseFullScreenIntent()
+    }
+
+    fun openFullScreenNotificationsSettings(activity: Activity?) {
+        val canUseFullScreenIntent = canUseFullScreenIntent()
+
+        if (!canUseFullScreenIntent && Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             val intent = Intent(Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT).apply {
                 data = Uri.fromParts("package", activity?.packageName, null)
             }

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/FlutterCallkitIncomingPlugin.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/FlutterCallkitIncomingPlugin.kt
@@ -278,9 +278,15 @@ class FlutterCallkitIncomingPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                     callkitNotificationManager?.requestNotificationPermission(activity, map)
                 }
 
-                "requestFullIntentPermission" -> {
-                    callkitNotificationManager?.requestFullIntentPermission(activity)
+                "canUseFullScreenIntent" -> {
+                    val canUse = callkitNotificationManager?.canUseFullScreenIntent()
+                    result.success(canUse)
                 }
+
+                "openFullScreenNotificationsSettings" -> {
+                    callkitNotificationManager?.openFullScreenNotificationsSettings(activity)
+                }
+
                 // EDIT - clear the incoming notification/ring (after accept/decline/timeout)
                 "hideCallkitIncoming" -> {
                     val data = Data(call.arguments() ?: HashMap())
@@ -288,13 +294,9 @@ class FlutterCallkitIncomingPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                     callkitNotificationManager?.clearIncomingNotification(data.toBundle(), false)
                 }
 
-                "endNativeSubsystemOnly" -> {
+                "endNativeSubsystemOnly" -> {}
 
-                }
-
-                "setAudioRoute" -> {
-
-                }
+                "setAudioRoute" -> {}
             }
         } catch (error: Exception) {
             result.error("error", error.message, "")

--- a/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -197,11 +197,17 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
             self.silenceEvents = silence
             result("OK")
             break;
-        case "requestNotificationPermission": 
+        // Android only
+        case "requestNotificationPermission":
             result("OK")
             break
-         case "requestFullIntentPermission": 
+        // Android only
+        case "openFullScreenNotificationsSettings":
             result("OK")
+            break
+        // Android only
+        case "canUseFullScreenIntent":
+            result(true)
             break
         case "hideCallkitIncoming":
             result("OK")

--- a/lib/flutter_callkit_incoming.dart
+++ b/lib/flutter_callkit_incoming.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'entities/entities.dart';
@@ -123,16 +124,38 @@ class FlutterCallkitIncoming {
     return await _channel.invokeMethod("silenceEvents", false);
   }
 
-  /// Request permisstion show notification for Android(13)
+  /// Request permission show notification for Android(13)
   /// Only Android: show request permission post notification for Android 13+
   static Future requestNotificationPermission(dynamic data) async {
     return await _channel.invokeMethod("requestNotificationPermission", data);
   }
 
-  /// Request permisstion show notification for Android(14)+
-  /// Only Android: show request permission for ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT
-  static Future requestFullIntentPermission() async {
-    return await _channel.invokeMethod("requestFullIntentPermission");
+  /// Opens full screen notifications settings activity. Android only.
+  ///
+  /// For devices with Android SDK API >= 34, opens the full screen notification settings activity declared by
+  /// the `Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT` intent. For devices with Android SDK API < 34
+  /// and iOS devices, does nothing.
+  static Future<void> openFullScreenNotificationsSettings() async {
+    try {
+      await _channel.invokeMethod("openFullScreenNotificationsSettings");
+    } catch (e) {
+      debugPrint('Error when opening full screen notifications settings: $e');
+    }
+  }
+
+  /// Returns `true` if the app has permission to show full screen notifications when the device is locked.
+  ///
+  /// On iOS, always returns `true`. On Android:
+  /// - for devices with Android SDK API >= 34, checks whether the `USE_FULL_SCREEN_INTENT` has been granted;
+  /// - for devices with Android SDK API < 34, returns `true`.
+  static Future<bool> canUseFullScreenIntent() async {
+    try {
+      final result = await _channel.invokeMethod('canUseFullScreenIntent');
+      return result as bool;
+    } catch (e) {
+      debugPrint('Error while calling canUseFullScreenIntent: $e');
+      return false;
+    }
   }
 
   static CallEvent? _receiveCallEvent(dynamic data) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_callkit_incoming
 description: Flutter Callkit Incoming to show callkit screen in your Flutter app.
-version: 2.5.2
+version: 2.5.3
 homepage: https://github.com/hiennguyen92/flutter_callkit_incoming
 repository: https://github.com/hiennguyen92/flutter_callkit_incoming
 issue_tracker: https://github.com/hiennguyen92/flutter_callkit_incoming/issues


### PR DESCRIPTION
### Short description

This pull request:
- introduces new method, `canUseFullScreenIntent`, for determining whether the app can show full screen notifications (Android only);
- breaking: renames `requestFullIntentPermission` to `openFullScreenNotificationsSettings` to better reflect what this method does.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore change (changes that do not relate to a fix or feature and don't modify src or test files e.g. updating dependencies)
- [ ] Refactor (a code change that neither fixes a bug nor adds a feature)
- [ ] This change requires a documentation update

### Tracker ID

[EFA-36](https://extrasafe-team.atlassian.net/browse/EFA-36)


[EFA-36]: https://extrasafe-team.atlassian.net/browse/EFA-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ