### PR TITLE
fix: allow using asset avatar in notifications

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
@@ -184,16 +184,14 @@ class CallkitIncomingActivity : Activity() {
 
         val isShowLogo = data?.getBoolean(CallkitConstants.EXTRA_CALLKIT_IS_SHOW_LOGO, false)
         ivLogo.visibility = if (isShowLogo == true) View.VISIBLE else View.INVISIBLE
-        var logoUrl = data?.getString(CallkitConstants.EXTRA_CALLKIT_LOGO_URL, "")
+        val logoUrl = data?.getString(CallkitConstants.EXTRA_CALLKIT_LOGO_URL, "")
 
         if (!logoUrl.isNullOrEmpty()) {
-            if (!logoUrl.startsWith("http://", true) && !logoUrl.startsWith("https://", true)) {
-                logoUrl = String.format("file:///android_asset/flutter_assets/%s", logoUrl)
-            }
+            val url = getAssetUrl(logoUrl)
             val headers =
-                data?.getSerializable(CallkitConstants.EXTRA_CALLKIT_HEADERS) as HashMap<String, Any?>
+                data.getSerializable(CallkitConstants.EXTRA_CALLKIT_HEADERS) as HashMap<String, Any?>
             getPicassoInstance(this@CallkitIncomingActivity, headers)
-                .load(logoUrl)
+                .load(url)
                 .placeholder(R.drawable.transparent)
                 .error(R.drawable.transparent)
                 .into(ivLogo)
@@ -201,11 +199,12 @@ class CallkitIncomingActivity : Activity() {
 
         val avatarUrl = data?.getString(CallkitConstants.EXTRA_CALLKIT_AVATAR, "")
         if (!avatarUrl.isNullOrEmpty()) {
+            val url = getAssetUrl(avatarUrl)
             ivAvatar.visibility = View.VISIBLE
             val headers =
                 data.getSerializable(CallkitConstants.EXTRA_CALLKIT_HEADERS) as HashMap<String, Any?>
             getPicassoInstance(this@CallkitIncomingActivity, headers)
-                .load(avatarUrl)
+                .load(url)
                 .placeholder(R.drawable.ic_default_avatar)
                 .error(R.drawable.ic_default_avatar)
                 .into(ivAvatar)
@@ -350,6 +349,17 @@ class CallkitIncomingActivity : Activity() {
 
     private fun finishTask() {
         finishAndRemoveTask()
+    }
+
+    private fun getAssetUrl(url: String): String {
+        val startsWithHttp = url.startsWith("http://", true)
+        val startsWithHttps = url.startsWith("https://", true)
+
+        return if (startsWithHttp || startsWithHttps) {
+            url
+        } else {
+            "file:///$url"
+        }
     }
 
     private fun getPicassoInstance(context: Context, headers: HashMap<String, Any?>): Picasso {

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitNotificationManager.kt
@@ -163,8 +163,9 @@ class CallkitNotificationManager(private val context: Context) {
                     CallkitConstants.EXTRA_CALLKIT_HANDLE, ""
                 )
             )
-            val avatarUrl = data.getString(CallkitConstants.EXTRA_CALLKIT_AVATAR, "")
-            if (avatarUrl != null && avatarUrl.isNotEmpty()) {
+
+            val avatarUrl = getAvatarUrl(data)
+            if (avatarUrl != null) {
                 val headers =
                     data.getSerializable(CallkitConstants.EXTRA_CALLKIT_HEADERS) as HashMap<String, Any?>
                 getPicassoInstance(context, headers).load(avatarUrl)
@@ -240,8 +241,9 @@ class CallkitNotificationManager(private val context: Context) {
             R.id.tvAccept,
             if (TextUtils.isEmpty(textAccept)) context.getString(R.string.text_accept) else textAccept
         )
-        val avatarUrl = data.getString(CallkitConstants.EXTRA_CALLKIT_AVATAR, "")
-        if (avatarUrl != null && avatarUrl.isNotEmpty()) {
+
+        val avatarUrl = getAvatarUrl(data)
+        if (avatarUrl != null) {
             val headers =
                 data.getSerializable(CallkitConstants.EXTRA_CALLKIT_HEADERS) as HashMap<String, Any?>
             getPicassoInstance(context, headers).load(avatarUrl).transform(CircleTransform())
@@ -309,8 +311,8 @@ class CallkitNotificationManager(private val context: Context) {
                 if (TextUtils.isEmpty(textCallback)) context.getString(R.string.text_call_back) else textCallback
             )
 
-            val avatarUrl = data.getString(CallkitConstants.EXTRA_CALLKIT_AVATAR, "")
-            if (avatarUrl != null && avatarUrl.isNotEmpty()) {
+            val avatarUrl = getAvatarUrl(data)
+            if (avatarUrl != null) {
                 val headers =
                     data.getSerializable(CallkitConstants.EXTRA_CALLKIT_HEADERS) as HashMap<String, Any?>
 
@@ -331,8 +333,8 @@ class CallkitNotificationManager(private val context: Context) {
                     CallkitConstants.EXTRA_CALLKIT_HANDLE, ""
                 )
             )
-            val avatarUrl = data.getString(CallkitConstants.EXTRA_CALLKIT_AVATAR, "")
-            if (avatarUrl != null && avatarUrl.isNotEmpty()) {
+            val avatarUrl = getAvatarUrl(data)
+            if (avatarUrl != null) {
                 val headers =
                     data.getSerializable(CallkitConstants.EXTRA_CALLKIT_HEADERS) as HashMap<String, Any?>
 
@@ -447,6 +449,23 @@ class CallkitNotificationManager(private val context: Context) {
                 NotificationManager.IMPORTANCE_LOW // disables notification popup for ongoing call
             )
             createNotificationChannel(channelOngoingCall)
+        }
+    }
+
+    private fun getAvatarUrl(bundle: Bundle): String? {
+        val bundleAvatarUrl = bundle.getString(CallkitConstants.EXTRA_CALLKIT_AVATAR, "")
+
+        return if (bundleAvatarUrl.isNotBlank()) {
+            val startsWithHttp = bundleAvatarUrl.startsWith("http://", true)
+            val startsWithHttps = bundleAvatarUrl.startsWith("https://", true)
+
+            if (startsWithHttp || startsWithHttps) {
+                bundleAvatarUrl
+            } else {
+                "file:///$bundleAvatarUrl"
+            }
+        } else {
+            null
         }
     }
 

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/OngoingNotificationService.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/OngoingNotificationService.kt
@@ -111,8 +111,8 @@ class OngoingNotificationService : Service() {
                     CallkitConstants.EXTRA_CALLKIT_HANDLE, ""
                 )
             )
-            val avatarUrl = data.getString(CallkitConstants.EXTRA_CALLKIT_AVATAR, "")
-            if (avatarUrl != null && avatarUrl.isNotEmpty()) {
+            val avatarUrl = getAvatarUrl(data)
+            if (avatarUrl != null) {
                 val headers =
                     data.getSerializable(CallkitConstants.EXTRA_CALLKIT_HEADERS) as HashMap<String, Any?>
 
@@ -219,6 +219,23 @@ class OngoingNotificationService : Service() {
             override fun onBitmapFailed(e: Exception?, errorDrawable: Drawable?) {}
 
             override fun onPrepareLoad(placeHolderDrawable: Drawable?) {}
+        }
+    }
+
+    private fun getAvatarUrl(bundle: Bundle): String? {
+        val bundleAvatarUrl = bundle.getString(CallkitConstants.EXTRA_CALLKIT_AVATAR, "")
+
+        return if (bundleAvatarUrl.isNotBlank()) {
+            val startsWithHttp = bundleAvatarUrl.startsWith("http://", true)
+            val startsWithHttps = bundleAvatarUrl.startsWith("https://", true)
+
+            if (startsWithHttp || startsWithHttps) {
+                bundleAvatarUrl
+            } else {
+                "file:///$bundleAvatarUrl"
+            }
+        } else {
+            null
         }
     }
 


### PR DESCRIPTION
### Short description

This pull request allows to supply a local asset, e.g. a launcher icon asset, in the `avatar` parameter for display in regular, full screen, and ongoing notifications. The avatar asset url can be specified in the following format: `android_asset/flutter_assets/assets/<path_to_asset_in_flutter_assets_folder>`.

Relevant issues and pull requests from the original repository:
- issue: https://github.com/hiennguyen92/flutter_callkit_incoming/issues/357
- pull request: https://github.com/hiennguyen92/flutter_callkit_incoming/pull/674

<image width="300" src="https://github.com/user-attachments/assets/85d5e247-f2ff-43e4-aae8-651416b24fe6" />
<image width="300" src="https://github.com/user-attachments/assets/1b6d7dd8-9c38-436e-841e-205660266e45" />

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore change (changes that do not relate to a fix or feature and don't modify src or test files e.g. updating dependencies)
- [ ] Refactor (a code change that neither fixes a bug nor adds a feature)
- [ ] This change requires a documentation update

### Tracker ID

[EFA-167](https://extrasafe-team.atlassian.net/browse/EFA-167)


[EFA-167]: https://extrasafe-team.atlassian.net/browse/EFA-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ