### PR TITLE
fix: request all foreground service types

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
@@ -147,7 +147,7 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
                         val onGoingNotificationIntent =
                             Intent(context, OngoingNotificationService::class.java);
                         onGoingNotificationIntent.putExtras(data)
-                        context.startService(onGoingNotificationIntent)
+                        context.startForegroundService(onGoingNotificationIntent)
                     }
                     addCall(context, Data.fromBundle(data), true)
                 } catch (error: Exception) {
@@ -165,7 +165,7 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
                         val onGoingNotificationIntent =
                             Intent(context, OngoingNotificationService::class.java);
                         onGoingNotificationIntent.putExtras(data)
-                        context.startService(onGoingNotificationIntent)
+                        context.startForegroundService(onGoingNotificationIntent)
                     }
                     addCall(context, Data.fromBundle(data), true)
                 } catch (error: Exception) {

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/OngoingNotificationService.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/OngoingNotificationService.kt
@@ -159,19 +159,22 @@ class OngoingNotificationService : Service() {
         }
         notificationBuilder.setOngoing(true)
         val notification = notificationBuilder.build()
-        val typeCall = data.getInt(CallkitConstants.EXTRA_CALLKIT_TYPE, -1)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            val serviceType = if (typeCall > 0) {
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA
-            } else {
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            // if the camera permission is granted add it
+            if (cameraPermission == permissionGrantedFlag) {
+                startForeground(
+                    onGoingNotificationId,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA,
+                )
             }
 
+            // always request the microphone service permission to be able to record audio while in background
             startForeground(
                 onGoingNotificationId,
                 notification,
-                serviceType,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
             )
         } else {
             startForeground(onGoingNotificationId, notification)

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/OngoingNotificationService.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/OngoingNotificationService.kt
@@ -103,8 +103,7 @@ class OngoingNotificationService : Service() {
                 val headers =
                     data.getSerializable(CallkitConstants.EXTRA_CALLKIT_HEADERS) as HashMap<String, Any?>
 
-                getPicassoInstance(this@OngoingNotificationService, headers).load(avatarUrl)
-                    .transform(CircleTransform())
+                getPicassoInstance(this, headers).load(avatarUrl).transform(CircleTransform())
                     .into(createAvatarTargetCustom(onGoingNotificationId))
             }
             notificationBuilder.setStyle(NotificationCompat.DecoratedCustomViewStyle())
@@ -186,14 +185,16 @@ class OngoingNotificationService : Service() {
 
 
     private fun getAppPendingIntent(notificationId: Int, data: Bundle): PendingIntent {
-        val intent: Intent? = AppUtils.getAppIntent(this@OngoingNotificationService, data = data)
         return PendingIntent.getActivity(
-            this@OngoingNotificationService, notificationId, intent, getFlagPendingIntent()
+            this,
+            notificationId,
+            AppUtils.getAppIntent(this, data = data),
+            getFlagPendingIntent(),
         )
     }
 
     override fun onBind(p0: Intent?): IBinder? {
-        return null;
+        return null
     }
 
     private fun getFlagPendingIntent(): Int {
@@ -227,11 +228,9 @@ class OngoingNotificationService : Service() {
                 getNotificationManager().notify(notificationId, notificationBuilder.build())
             }
 
-            override fun onBitmapFailed(e: Exception?, errorDrawable: Drawable?) {
-            }
+            override fun onBitmapFailed(e: Exception?, errorDrawable: Drawable?) {}
 
-            override fun onPrepareLoad(placeHolderDrawable: Drawable?) {
-            }
+            override fun onPrepareLoad(placeHolderDrawable: Drawable?) {}
         }
     }
 
@@ -274,7 +273,7 @@ class OngoingNotificationService : Service() {
     }
 
     private fun getNotificationManager(): NotificationManagerCompat {
-        return NotificationManagerCompat.from(this@OngoingNotificationService)
+        return NotificationManagerCompat.from(this)
     }
 }
 

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/OngoingNotificationService.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/OngoingNotificationService.kt
@@ -1,7 +1,6 @@
 package com.hiennv.flutter_callkit_incoming
 
 import android.Manifest
-import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -39,7 +38,6 @@ class OngoingNotificationService : Service() {
         return START_REDELIVER_INTENT
     }
 
-    @SuppressLint("MissingPermission")
     private fun showOngoingCallNotification(data: Bundle) {
         val cameraPermission =
             PermissionChecker.checkSelfPermission(this, Manifest.permission.CAMERA)
@@ -213,10 +211,17 @@ class OngoingNotificationService : Service() {
         return Picasso.Builder(context).downloader(OkHttp3Downloader(client)).build()
     }
 
-    @SuppressLint("MissingPermission")
     private fun createAvatarTargetCustom(notificationId: Int): Target {
         return object : Target {
             override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    val canPostNotifications = PermissionChecker.checkSelfPermission(
+                        this@OngoingNotificationService, Manifest.permission.POST_NOTIFICATIONS
+                    )
+
+                    if (canPostNotifications != PermissionChecker.PERMISSION_GRANTED) return
+                }
+
                 notificationViews?.setImageViewBitmap(R.id.ivAvatar, bitmap)
                 notificationViews?.setViewVisibility(R.id.ivAvatar, View.VISIBLE)
                 getNotificationManager().notify(notificationId, notificationBuilder.build())
@@ -230,10 +235,17 @@ class OngoingNotificationService : Service() {
         }
     }
 
-    @SuppressLint("MissingPermission")
     private fun createAvatarTargetDefault(notificationId: Int): Target {
         return object : Target {
             override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    val canPostNotifications = PermissionChecker.checkSelfPermission(
+                        this@OngoingNotificationService, Manifest.permission.POST_NOTIFICATIONS
+                    )
+
+                    if (canPostNotifications != PermissionChecker.PERMISSION_GRANTED) return
+                }
+
                 notificationBuilder.setLargeIcon(bitmap)
                 getNotificationManager().notify(notificationId, notificationBuilder.build())
             }


### PR DESCRIPTION
### Short description

This pull request fixes an issue where only one of the required foreground service types was requested, resulting in a possible situation where user video is visible while in background, but the microphone access stops after around 5 seconds.

Additionally, this pull request adds checks for `POST_NOTIFICATIONS` permissions and removes lint suppressions.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore change (changes that do not relate to a fix or feature and don't modify src or test files e.g. updating dependencies)
- [ ] Refactor (a code change that neither fixes a bug nor adds a feature)
- [ ] This change requires a documentation update

### Tracker ID

[EFA-191](https://extrasafe-team.atlassian.net/browse/EFA-191)


[EFA-191]: https://extrasafe-team.atlassian.net/browse/EFA-191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ