### PR TITLE
fix: Properly destroy call activity

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitConstants.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitConstants.kt
@@ -3,6 +3,8 @@ package com.hiennv.flutter_callkit_incoming
 object CallkitConstants {
     const val ACTION_CALL_INCOMING =
         "com.hiennv.flutter_callkit_incoming.ACTION_CALL_INCOMING"
+    const val ACTION_ENDED_CALL_INCOMING =
+        "com.hiennv.flutter_callkit_incoming.ACTION_ENDED_CALL_INCOMING"
     const val ACTION_CALL_START = "com.hiennv.flutter_callkit_incoming.ACTION_CALL_START"
     const val ACTION_CALL_ACCEPT =
         "com.hiennv.flutter_callkit_incoming.ACTION_CALL_ACCEPT"

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingBroadcastReceiver.kt
@@ -12,7 +12,6 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
         private const val TAG = "CallkitIncomingBroadcastReceiver"
         private const val CLASS_NAME =
             "com.hiennv.flutter_callkit_incoming.CallkitIncomingBroadcastReceiver"
-        var silenceEvents = false
 
         fun getIntent(context: Context, action: String, data: Bundle?) =
             Intent().apply {
@@ -221,8 +220,6 @@ class CallkitIncomingBroadcastReceiver : BroadcastReceiver() {
     }
 
     private fun sendEventFlutter(event: String, data: Bundle) {
-        if (silenceEvents) return
-
         val android = mapOf(
             "isCustomNotification" to data.getBoolean(
                 CallkitConstants.EXTRA_CALLKIT_IS_CUSTOM_NOTIFICATION,

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/FlutterCallkitIncomingPlugin.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/FlutterCallkitIncomingPlugin.kt
@@ -258,14 +258,14 @@ class FlutterCallkitIncomingPlugin : FlutterPlugin, MethodCallHandler, ActivityA
                     result.success(getDataActiveCallsForFlutter(context))
                 }
 
+                // iOS only
                 "getDevicePushTokenVoIP" -> {
                     result.success("")
                 }
 
+                // iOS only
                 "silenceEvents" -> {
-                    val silence = call.arguments as? Boolean ?: false
-                    CallkitIncomingBroadcastReceiver.silenceEvents = silence
-                    result.success("")
+                    result.success("OK")
                 }
 
                 "requestNotificationPermission" -> {

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/OngoingNotificationService.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/OngoingNotificationService.kt
@@ -33,6 +33,8 @@ class OngoingNotificationService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent != null && intent.extras != null) {
             showOngoingCallNotification(intent.extras!!)
+        } else {
+            stopSelf()
         }
 
         return START_STICKY


### PR DESCRIPTION
### Short description

This pull request:
- fixes an issue where full screen call notification activity would not be hidden when calling `hideIncomingNotification`;
- fixes an issue where the foreground service of the ongoing call notification would throw an error if camera and microphone permissions were not granted beforehand;
- breaking: removes `silenceEvents`.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore change (changes that do not relate to a fix or feature and don't modify src or test files e.g. updating dependencies)
- [ ] Refactor (a code change that neither fixes a bug nor adds a feature)
- [ ] This change requires a documentation update
