### PR TITLE
fix!: [EFA-200] Don't configure iOS audio session

### DIFF
--- a/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -443,23 +443,23 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
     }
     
     func configurAudioSession(){
-        if data?.configureAudioSession != false {
-            let session = AVAudioSession.sharedInstance()
-            do{
-                try session.setCategory(AVAudioSession.Category.playAndRecord, options: [
-                    .allowBluetoothA2DP,
-                    .duckOthers,
-                    .allowBluetooth,
-                ])
-                
-                try session.setMode(self.getAudioSessionMode(data?.audioSessionMode))
-                try session.setActive(data?.audioSessionActive ?? true)
-                try session.setPreferredSampleRate(data?.audioSessionPreferredSampleRate ?? 44100.0)
-                try session.setPreferredIOBufferDuration(data?.audioSessionPreferredIOBufferDuration ?? 0.005)
-            }catch{
-                print(error)
-            }
-        }
+//        if data?.configureAudioSession != false {
+//            let session = AVAudioSession.sharedInstance()
+//            do{
+//                try session.setCategory(AVAudioSession.Category.playAndRecord, options: [
+//                    .allowBluetoothA2DP,
+//                    .duckOthers,
+//                    .allowBluetooth,
+//                ])
+//                
+//                try session.setMode(self.getAudioSessionMode(data?.audioSessionMode))
+//                try session.setActive(data?.audioSessionActive ?? true)
+//                try session.setPreferredSampleRate(data?.audioSessionPreferredSampleRate ?? 44100.0)
+//                try session.setPreferredIOBufferDuration(data?.audioSessionPreferredIOBufferDuration ?? 0.005)
+//            }catch{
+//                print(error)
+//            }
+//        }
     }
     
     func getAudioSessionMode(_ audioSessionMode: String?) -> AVAudioSession.Mode {


### PR DESCRIPTION
### Short description

This pull request removes code that configures audio session on iOS because it was interfering with `CallKit`'s audio session.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore change (changes that do not relate to a fix or feature and don't modify src or test files e.g. updating dependencies)
- [ ] Refactor (a code change that neither fixes a bug nor adds a feature)
- [ ] This change requires a documentation update

### Tracker ID

[EFA-200](https://extrasafe-team.atlassian.net/browse/EFA-200)


[EFA-200]: https://extrasafe-team.atlassian.net/browse/EFA-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ