### PR TITLE
feat: [EFA-255] Always send 'call ended' event

### DIFF
--- a/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
+++ b/ios/Classes/SwiftFlutterCallkitIncomingPlugin.swift
@@ -310,13 +310,16 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
     
     @objc public func endCall(_ data: Data) {
         var call: Call? = nil
-        if(self.isFromPushKit){
+        if self.isFromPushKit {
             call = Call(uuid: UUID(uuidString: self.data!.uuid)!, data: data)
             self.isFromPushKit = false
-            self.sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_ENDED, data.toJSON())
-        }else {
+        } else {
             call = Call(uuid: UUID(uuidString: data.uuid)!, data: data)
         }
+        self.sendEvent(
+            SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_ENDED,
+            data.toJSON()
+        )
         self.callManager.endCall(call: call!)
     }
     
@@ -558,7 +561,7 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
     
     public func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
         guard let call = self.callManager.callWithUUID(uuid: action.callUUID) else {
-            if(self.answerCall == nil && self.outgoingCall == nil){
+            if self.answerCall == nil && self.outgoingCall == nil {
                 sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_TIMEOUT, self.data?.toJSON())
             } else {
                 sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_ENDED, self.data?.toJSON())
@@ -568,14 +571,17 @@ public class SwiftFlutterCallkitIncomingPlugin: NSObject, FlutterPlugin, CXProvi
         }
         call.endCall()
         self.callManager.removeCall(call)
-        if (self.answerCall == nil && self.outgoingCall == nil) {
-            sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_DECLINE, self.data?.toJSON())
+        if self.answerCall == nil && self.outgoingCall == nil {
+            sendEvent(
+                SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_DECLINE,
+                self.data?.toJSON()
+            )
             if let appDelegate = UIApplication.shared.delegate as? CallkitIncomingAppDelegate {
                 appDelegate.onDecline(call, action)
             } else {
                 action.fulfill()
             }
-        }else {
+        } else {
             self.answerCall = nil
             sendEvent(SwiftFlutterCallkitIncomingPlugin.ACTION_CALL_ENDED, call.data.toJSON())
             if let appDelegate = UIApplication.shared.delegate as? CallkitIncomingAppDelegate {


### PR DESCRIPTION
### Short description

This pull request changes the iOS plugin's `endCall` method behaviour to always send the 'call ended' event.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore change (changes that do not relate to a fix or feature and don't modify src or test files e.g. updating dependencies)
- [ ] Refactor (a code change that neither fixes a bug nor adds a feature)
- [ ] This change requires a documentation update

### Tracker ID

[EFA-255](https://extrasafe-team.atlassian.net/browse/EFA-255)

[EFA-255]: https://extrasafe-team.atlassian.net/browse/EFA-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ